### PR TITLE
use pip to install elastalert

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,7 +10,13 @@ verifier:
   name: inspec
 
 platforms:
-  - name: debian-jessie
+  - name: debian
+    run_list:
+      - recipe[elastalert_test::elasticsearch]
+  - name: centos-6
+    run_list:
+      - recipe[elastalert_test::elasticsearch]
+  - name: centos-7
     run_list:
       - recipe[elastalert_test::elasticsearch]
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,4 +1,3 @@
----
 driver:
   name: docker
   use_sudo: false
@@ -11,14 +10,8 @@ verifier:
 
 platforms:
   - name: debian
-    run_list:
-      - recipe[elastalert_test::elasticsearch]
   - name: centos-6
-    run_list:
-      - recipe[elastalert_test::elasticsearch]
   - name: centos-7
-    run_list:
-      - recipe[elastalert_test::elasticsearch]
 
 suites:
   - name: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rvm:
 sudo: required
 services:
     - docker
+    - elasticsearch
+before_script:
+    - sleep 10
 install:
     - bundle install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+rvm:
+    - 2.3.0
+sudo: required
+services:
+    - docker
+install:
+    - bundle install
+script:
+    - kitchen test

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ In more details:
 Create wrapper around this cookbook and adjust attributes to your needs.
 
 ### Attributes
-* `node['elastalert']['repository']` - git repository of elastalert, default `https://github.com/Yelp/elastalert.git`
-* `node['elastalert']['version']` - commit hash or tag to checkout from elastalert git repo, default `v0.1.3`
+* `node['elastalert']['version']` - elastalert version to install from pip, default `nil` meaning it will take the latest
 * `node['elastalert']['elasticsearch']['hostname']` - hostname of elasticsearch to use, default `localhost`
 * `node['elastalert']['elasticsearch']['port']` - port of elasticsearch to use, default `9200`
 * `node['elastalert']['elasticsearch']['index']` - name of index to be created by elastalert, default `elastalert_status`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,4 @@
-default['elastalert']['repository'] = 'https://github.com/Yelp/elastalert.git'
-default['elastalert']['version'] = 'v0.1.3'
+default['elastalert']['version'] = nil
 
 default['elastalert']['elasticsearch']['hostname'] = 'localhost'
 default['elastalert']['elasticsearch']['port'] = 9200

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,6 @@ version '0.1.1'
 supports 'debian'
 
 depends 'poise-python'
-depends 'git'
 depends 'managed_directory'
 depends 'supervisor'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,8 +35,10 @@ directory elast_dir do
 end
 
 # needed for python
-%w(build-essential python-dev).each do |package|
-  apt_package package
+build_essentials = node['platform'] == 'centos' ? %w(make automake gcc gcc-c++ kernel-devel python-devel) : %w(build-essential python-dev)
+
+build_essentials.each do |package|
+  package package
 end
 
 python_runtime '2' # requriment of elastalert

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,15 +36,6 @@ end
 
 include_recipe 'git'
 
-git 'elastalert' do
-  repository elast_repo
-  revision elast_ver
-  destination elast_dir
-  user elast_user
-  group elast_group
-  action :checkout
-end
-
 # needed for python
 %w(build-essential python-dev).each do |package|
   apt_package package
@@ -58,23 +49,12 @@ python_virtualenv elast_venv do
   not_if { ::File.exist?(elast_venv) }
 end
 
-python_execute "#{elast_dir}/setup.py install" do
-  user elast_user
-  group elast_group
-  virtualenv elast_venv
-  cwd elast_dir
-  not_if { ::File.exist?("#{elast_venv}/bin/elastalert-create-index") }
-  notifies :install, "pip_requirements[#{elast_dir}/requirements.txt]", :immediately
-end
-
-pip_requirements "#{elast_dir}/requirements.txt" do
-  user elast_user
-  group elast_group
-  virtualenv elast_venv
-  options '-v'
-  cwd elast_dir
-  retries 1 # 1st try fails on clean up step when trying to remove not existing file, 2nd try is successful
-  action :nothing
+python_package 'elastalert' do
+    group elast_group
+    user elast_user
+    virtualenv elast_venv
+    package_name 'elastalert'
+  version elast_ver
 end
 
 python_execute 'setup elastalert index' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,8 +34,6 @@ directory elast_dir do
   mode '0755'
 end
 
-include_recipe 'git'
-
 # needed for python
 %w(build-essential python-dev).each do |package|
   apt_package package


### PR DESCRIPTION
uses `pip install` command to install elastalert instead of
* doing a git checkout
* run `setup.py`
* do a `pip install -r requirements.txt`

Note that the elastalert installed with this version will not work until this Pull Request gets merged:
https://github.com/Yelp/elastalert/pull/867