### PR TITLE
libffi-dev is needed for new versions >0.1.6 of elastalert

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,7 +46,7 @@ git 'elastalert' do
 end
 
 # needed for python
-%w(build-essential python-dev).each do |package|
+%w(build-essential python-dev libffi-dev).each do |package|
   apt_package package
 end
 


### PR DESCRIPTION
libffi-dev is needed by recent version of elastalert